### PR TITLE
DATA-1422 add date to logging

### DIFF
--- a/wherescape/logging.py
+++ b/wherescape/logging.py
@@ -96,7 +96,7 @@ def initialise_wherescape_logging(wherescape):
     """
 
     fmt = "[%(levelname)s] %(asctime)s %(filename)s %(funcName)s():%(lineno)i: %(message)s"
-    message_format = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")
+    message_format = logging.Formatter(fmt=fmt, datefmt="%Y-%m-%d %H:%M:%S")
 
     # Get the root logger
     logger = logging.getLogger()


### PR DESCRIPTION
### Issue number

DATA-1422 

### Expected behaviour

`wherescape.log` should have contained a date

### Actual behaviour

`wherescape.log` does not contain a date, just a timestamp

### Description of fix

Add a date to the python logging formatter datefmt

### Other info

None

