### PR TITLE
Add fact_dimension_join_check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.code-workspace
 .vscode/
 wherescape.log
+ws_env.py
 .DS_Store
 *.pyc
 __pycache__

--- a/validators/fact_dimension_join.py
+++ b/validators/fact_dimension_join.py
@@ -65,7 +65,7 @@ def check_fact_dimension_join(output_file_location):
         row["count_of_0_key_records"] = result[0][1]
         rows.append(row)
 
-    keys = ['date', cd ../../'table', 'attribute',
+    keys = ['date', 'table', 'attribute',
             'count_of_all_records', 'count_of_0_key_records']
     if rows:
         # write the results to the file

--- a/validators/fact_dimension_join.py
+++ b/validators/fact_dimension_join.py
@@ -5,7 +5,7 @@ Module with function to validate fact-dimension joins
 import csv
 import os
 from datetime import datetime
-from wherescape.wherescape import WhereScape
+from wherescape_os.wherescape import WhereScape
 
 
 def check_fact_dimension_join(output_file_location):

--- a/validators/fact_dimension_join.py
+++ b/validators/fact_dimension_join.py
@@ -47,7 +47,7 @@ def check_fact_dimension_join(output_file_location):
         list_of_attributes.append((column_name, fq_table_name))
 
     rows = []
-    date = datetime.now().strftime('%y-%m-%d')
+    date = datetime.now().strftime('%Y-%m-%d')
     for column_name, fq_table_name in list_of_attributes:
         row = {}
         sql = f"""
@@ -65,7 +65,7 @@ def check_fact_dimension_join(output_file_location):
         row["count_of_0_key_records"] = result[0][1]
         rows.append(row)
 
-    keys = ['date', 'table', 'attribute',
+    keys = ['date', cd ../../'table', 'attribute',
             'count_of_all_records', 'count_of_0_key_records']
     if rows:
         # write the results to the file

--- a/validators/fact_dimension_join.py
+++ b/validators/fact_dimension_join.py
@@ -17,6 +17,7 @@ def check_fact_dimension_join(output_file_location):
     - all columns with foreign keys to dimensions
 
     Does a count of all references to 0-dimension keys.
+    Does a count of all fact records
 
     Creates a file in  output_file_location
     """
@@ -46,23 +47,25 @@ def check_fact_dimension_join(output_file_location):
         list_of_attributes.append((column_name, fq_table_name))
 
     rows = []
+    date = datetime.now().strftime('%y-%m-%d')
     for column_name, fq_table_name in list_of_attributes:
         row = {}
         sql = f"""
-        select 
+        select
            count(*)                                  as count_of_all_records
-        ,  count(*) filter (where {column_name} = 0) as count_of_0_key_records  
-        from {fq_table_name} 
+        ,  count(*) filter (where {column_name} = 0) as count_of_0_key_records 
+        from {fq_table_name}
         """
         result = wherescape.query_target(
             sql)
+        row["date"] = date
         row["table"] = fq_table_name
         row["attribute"] = column_name
         row["count_of_all_records"] = result[0][0]
         row["count_of_0_key_records"] = result[0][1]
         rows.append(row)
 
-    keys = ['table', 'attribute',
+    keys = ['date', 'table', 'attribute',
             'count_of_all_records', 'count_of_0_key_records']
     if rows:
         # write the results to the file

--- a/validators/fact_dimension_join.py
+++ b/validators/fact_dimension_join.py
@@ -1,0 +1,83 @@
+"""
+Module with function to validate fact-dimension joins
+
+"""
+import csv
+import os
+from datetime import datetime
+from wherescape.wherescape import WhereScape
+
+
+def check_fact_dimension_join(output_file_location):
+    """
+    Checks fact-dimension joins
+
+    Retrieves from the repository:
+    - all fact table names from the repository and,
+    - all columns with foreign keys to dimensions
+
+    Does a count of all references to 0-dimension keys.
+
+    Creates a file in  output_file_location
+    """
+    wherescape = WhereScape()
+
+    sql = """
+    select dt_schema, ft_table_name, fc_col_name
+      from dbo.ws_fact_col
+      left join dbo.ws_fact_tab on fc_obj_key = ft_obj_key
+      left join dbo.ws_obj_object on oo_obj_key = ft_obj_key
+      left join dbo.ws_dbc_target on dt_target_key = oo_target_key
+     where fc_key_type = '2'
+    -- and fc_col_name like 'dim_%'
+     order by 1,2
+    """
+
+    repository_results = wherescape.query_meta(sql)
+
+    facts = set()
+    list_of_attributes = []
+    for result in repository_results:
+        schema, table_name, column_name = result
+        fq_table_name = schema + "." + table_name
+        # add tablename to set
+        facts.add(fq_table_name)
+        # store attribute, tablename in list_of_attributes
+        list_of_attributes.append((column_name, fq_table_name))
+
+    rows = []
+    for column_name, fq_table_name in list_of_attributes:
+        row = {}
+        sql = f"""
+        select 
+           count(*)                                  as count_of_all_records
+        ,  count(*) filter (where {column_name} = 0) as count_of_0_key_records  
+        from {fq_table_name} 
+        """
+        result = wherescape.query_target(
+            sql)
+        row["table"] = fq_table_name
+        row["attribute"] = column_name
+        row["count_of_all_records"] = result[0][0]
+        row["count_of_0_key_records"] = result[0][1]
+        rows.append(row)
+
+    keys = ['table', 'attribute',
+            'count_of_all_records', 'count_of_0_key_records']
+    if rows:
+        # write the results to the file
+        filename = f"fact_dimension_check_result_{datetime.now().strftime('%y%m%d')}.csv"
+        filename = os.path.join(output_file_location, filename)
+        # logging.info("Writing file %s with %d lines",
+        #              filename, len(results))
+        with open(filename, "w", newline="") as output_file:
+            dict_writer = csv.DictWriter(output_file, keys)
+            dict_writer.writeheader()
+            dict_writer.writerows(rows)
+
+
+if __name__ == "__main__":
+    # import logging
+    from ws_env import setup_env
+    setup_env('not_relevant', schema="star")
+    check_fact_dimension_join(output_file_location=r"C:\Temp")

--- a/validators/readme.md
+++ b/validators/readme.md
@@ -1,0 +1,25 @@
+# Validators
+
+Validators are functions that can be called to validate target consistency
+
+These tests have been included for star models:
+
+- fact_dimension_join : counts the number of dimension keys in all facts that have the value 0, and also logs fact_dimension_size : counts the number of records in all facts and dimension
+
+To run this test from Wherescape, you need to create a dummy (load) table and a host script. The host script imports the check_fact_dimension_join from a directory that has to be in your pythonpath.  
+
+```python
+-- host script `python_create_csv_fact_dimension_check` 
+from check_fact_dimension_join import check_fact_dimension_join
+
+check_fact_dimension_join(output_file_location=r"C:\Temp")
+```
+
+When running this host script from the scheduler as, the dummy load table is takes care of setting the target environment variables.
+
+## Future
+
+These tests have been included for datastores:
+
+- datastore_dss_current_flag_P : counts the number of records with current_flag = P (future)
+- dim_hist_dss_current_flag_P : counts the number of records with current_flag = P (future)

--- a/validators/readme.md
+++ b/validators/readme.md
@@ -15,7 +15,7 @@ from wherescape_os.validators.fact_dimension_join import check_fact_dimension_jo
 check_fact_dimension_join(output_file_location=r"C:\Temp")
 ```
 
-When running this host script from the scheduler as, the dummy load table is takes care of setting the target environment variables.
+When running this host script from the scheduler, the dummy load table takes care of setting the target environment variables required by the script.
 
 ## Future
 

--- a/validators/readme.md
+++ b/validators/readme.md
@@ -10,7 +10,7 @@ To run this test from Wherescape, you need to create a dummy (load) table and a 
 
 ```python
 -- host script `python_create_csv_fact_dimension_check` 
-from check_fact_dimension_join import check_fact_dimension_join
+from wherescape_os.validators.fact_dimension_join import check_fact_dimension_join
 
 check_fact_dimension_join(output_file_location=r"C:\Temp")
 ```


### PR DESCRIPTION
### Issue number

DATA-1246

### Description of fix

In this pull-request a pyhton module is added that:
- Retrieves from the repository:
    - all fact table names and,
    - all columns with foreign keys to dimensions

It then does a count of all references to 0-dimension keys.

The output is put into a CSV-file that is put into `output_file_location`

### Other info

The python module uses `wherescape_os.wherescape`

