### PR TITLE
Adjust pagination to use X-Next-Page

### DIFF
--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -119,7 +119,7 @@ class Gitlab:
             try:
                 next_page = response.headers['X-Next-Page']
             except Exception as e:
-                print(e)
+                logging.error(e)
 
         return all_resources
 

--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -54,7 +54,7 @@ class Gitlab:
         since (string): [OPTIONAL] ISO formatted datetime string to indicate since which date you want values back (e.g. 2022-09-20T08:29:21)
 
         Example return:
-        https://gitlab.wearespindle.com/api/v4/projects?order_by=id&simple=true&per_page=50&page=1&sort=asc
+        https://gitlab.wearespindle.com/api/v4/projects?order_by=id&simple=true&per_page=50&page=1&sort=asc&updated_after=2022-09-20T08:29:21
 
         Returns:
         Formatted url which can be used to make the request

--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -51,9 +51,9 @@ class Gitlab:
             "current_page": string or int
         }
         simple (boolean): If the response of Gitlab should be simplified this needs to be set on True
-        since (string): [OPTIONAL] ISO formatted datetime string to indicate since which date you want values back
+        since (string): [OPTIONAL] ISO formatted datetime string to indicate since which date you want values back (e.g. 2022-09-20T08:29:21)
 
-        Example:
+        Example return:
         https://gitlab.wearespindle.com/api/v4/projects?order_by=id&simple=true&per_page=50&page=1&sort=asc
 
         Returns:
@@ -86,11 +86,8 @@ class Gitlab:
         keys_to_keep (list): List of keys returned by the API you want to keep
         per_page (int): How many results per page you would like to get
         simple (boolean): If the response of Gitlab should be simplified this needs to be set on True
-        since (string): ISO formatted datetime string to indicate since which date you want values back
+        since (string): ISO formatted datetime string to indicate since which date you want values back (e.g. 2022-09-20T08:29:21)
         overwrite (dict): A dictionary with a key, value pair to overwrite the none value with a fixed value
-
-        Example url:
-        https://gitlab.wearespindle.com/api/v4/projects/6/repository/commits?order_by=default&simple=false&per_page=50&page=22&sort=asc
 
         Returns:
         List of tuples with the values from the request

--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -59,7 +59,7 @@ class Gitlab:
         updated_since = f"&updated_after={since}" if since else ""
         sort_string = f"&sort=asc" if sort else ""
         pagination = f"per_page={page_variables['per_page']}&page={page_variables['next_page']}"
-        return f"{self.base_url}/{resource_api}?order_by={order_by}&simple={simple}&{pagination}{sort_string}{updated_since}&all=true"
+        return f"{self.base_url}/{resource_api}?order_by={order_by}&simple={simple}&{pagination}{sort_string}{updated_since}"
 
     def paginate_through_resource(
         self,
@@ -106,7 +106,7 @@ class Gitlab:
                 logging.info(
                     f"{url}\n Forbidden resource. If you need this resource, please check the user's rights"
                 )
-                continue
+                break
 
             response.raise_for_status()
 

--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -57,7 +57,7 @@ class Gitlab:
         Formatted url which can be used to make the request
         """
         updated_since = f"&updated_after={since}" if since else ""
-        sort_string = f"&sort=asc" if sort else ""
+        sort_string = "&sort=asc" if sort else ""
         pagination = f"per_page={page_variables['per_page']}&page={page_variables['next_page']}"
         return f"{self.base_url}/{resource_api}?order_by={order_by}&simple={simple}&{pagination}{sort_string}{updated_since}"
 

--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -53,6 +53,9 @@ class Gitlab:
         simple (boolean): If the response of Gitlab should be simplified this needs to be set on True
         since (string): [OPTIONAL] ISO formatted datetime string to indicate since which date you want values back
 
+        Example:
+        https://gitlab.wearespindle.com/api/v4/projects?order_by=id&simple=true&per_page=50&page=1&sort=asc
+
         Returns:
         Formatted url which can be used to make the request
         """
@@ -86,6 +89,9 @@ class Gitlab:
         since (string): ISO formatted datetime string to indicate since which date you want values back
         overwrite (dict): A dictionary with a key, value pair to overwrite the none value with a fixed value
 
+        Example url:
+        https://gitlab.wearespindle.com/api/v4/projects/6/repository/commits?order_by=default&simple=false&per_page=50&page=22&sort=asc
+
         Returns:
         List of tuples with the values from the request
 
@@ -116,10 +122,8 @@ class Gitlab:
                 cleaned_json = filter_dict(flatten_json(resource_object), keys_to_keep)
                 final_json = fill_out_empty_keys(cleaned_json, keys_to_keep, overwrite)
                 all_resources.append(list(final_json.values()))
-            try:
-                next_page = response.headers['X-Next-Page']
-            except Exception as e:
-                logging.error(e)
+            
+            next_page = response.headers.get('X-Next-Page')
 
         return all_resources
 


### PR DESCRIPTION
### Issue number

DATA 1593

### Expected behaviour

Retrieve all commits

### Actual behaviour

Only retrieve 50 commits.

### Description of fix

Adjust pagination to use different response header.


