### PR TITLE
change since and order for projects, since is not necessary

### DIFF
--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -118,9 +118,7 @@ class Gitlab:
         resource_api = "projects"
 
         params = {
-            "order_by": "id",
-            "updated_after": self.since,
-            "sort": "asc",
+            "order_by": "id"
         }
 
         all_projects = self.paginate_through_resource(


### PR DESCRIPTION

### Expected behaviour

Projects call was failing. It seems that gitlab changed the API.

### Actual behaviour


### Description of fix

Remove since and change the order by.

### Other info


