### PR TITLE
fix: break when we 404, because a project could have 0 branches

### DIFF
--- a/wherescape/connectors/gitlab/gitlab_wrapper.py
+++ b/wherescape/connectors/gitlab/gitlab_wrapper.py
@@ -87,6 +87,12 @@ class Gitlab:
                 )
                 break
 
+            if response.status_code == 404:
+                logging.info(
+                    f"{resource_api}\n Resource not found."
+                )
+                break
+
             response.raise_for_status()
 
             json_response = response.json()


### PR DESCRIPTION
### Issue number

DATA-1969

### Expected behaviour

Not let all the code fail if we hit a 404. It is oke to continue and look in the logs if needed.
It turned out that not all projects have branches.
