### PR TITLE
feat: uses sandbox acces token when in dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 virtual/
 config.py
 script_tester.py
+.python-version

--- a/wherescape/connectors/hubspot/collect_data.py
+++ b/wherescape/connectors/hubspot/collect_data.py
@@ -61,23 +61,24 @@ def hubspot_get_token(
     # return access token if it can be found with words in table
     for word in table_words:
         environment_parameter = parameter_name + "_" + word
-        access_token = wherescape_instance.read_parameter(environment_parameter)
 
-        if access_token:
-            logging.info("retreived acces token from %s" % environment_parameter)
-            return access_token
-        elif develop_env:
+        if develop_env:
             environment_parameter = environment_parameter + "_dev"
             access_token = wherescape_instance.read_parameter(environment_parameter)
             if access_token:
                 return access_token
 
+        access_token = wherescape_instance.read_parameter(environment_parameter)
+        if access_token:
+            logging.info("retreived acces token from %s" % environment_parameter)
+            return access_token
+
     # return acces token sandbox if environment is development
     if develop_env:
         logging.info("using developmental environment")
         parameter_name = parameter_name + "_dev"
-
-    logging.warn("no specified environment found")
+    else:
+        logging.info("no specified environment found")
     logging.info("retrieving access token from parameter %s" % parameter_name)
     # return access token on base name
     return wherescape_instance.read_parameter(parameter_name)

--- a/wherescape/connectors/hubspot/collect_data.py
+++ b/wherescape/connectors/hubspot/collect_data.py
@@ -41,7 +41,10 @@ def hubspot_get_token(
     wherescape_instance: WhereScape, table_name: str, develop_env: bool
 ):
     """
-    Function to get the hubspot access token from the table
+    Function to get the hubspot access token from the table.
+    First trying with environemnt specification from table_name.
+    Second checking for dev environment.
+    Last using base name.
 
     Parameters:
     - wherescape_instance (WhereScape): the wherescape database instance to connect to.
@@ -54,11 +57,8 @@ def hubspot_get_token(
     table_words = table_name.split("_")
 
     logging.info("retrieving access_token")
-    if develop_env:
-        logging.info("using developmental environment")
-        parameter_name = parameter_name + "_sandbox"
-        return wherescape_instance.read_parameter(parameter_name)
 
+    # return access token if it can be found with words in table
     for word in table_words:
         environment_parameter = parameter_name + "_" + word
         access_token = wherescape_instance.read_parameter(environment_parameter)
@@ -67,6 +67,12 @@ def hubspot_get_token(
             logging.info("retreived acces token from %s" % environment_parameter)
             return access_token
 
+    # return acces token sandbox if environment is development
+    if develop_env:
+        logging.info("using developmental environment")
+        parameter_name = parameter_name + "_sandbox"
+
     logging.warn("no specified environment found")
     logging.info("retrieving access token from parameter %s" % parameter_name)
+    # return access token on base name
     return wherescape_instance.read_parameter(parameter_name)

--- a/wherescape/connectors/hubspot/collect_data.py
+++ b/wherescape/connectors/hubspot/collect_data.py
@@ -56,7 +56,8 @@ def hubspot_get_token(
     logging.info("retrieving access_token")
     if develop_env:
         logging.info("using developmental environment")
-        return parameter_name + "_sandbox"
+        parameter_name = parameter_name + "_sandbox"
+        return wherescape_instance.read_parameter(parameter_name)
 
     for word in table_words:
         environment_parameter = parameter_name + "_" + word

--- a/wherescape/connectors/hubspot/collect_data.py
+++ b/wherescape/connectors/hubspot/collect_data.py
@@ -66,11 +66,16 @@ def hubspot_get_token(
         if access_token:
             logging.info("retreived acces token from %s" % environment_parameter)
             return access_token
+        elif develop_env:
+            environment_parameter = environment_parameter + "_dev"
+            access_token = wherescape_instance.read_parameter(environment_parameter)
+            if access_token:
+                return access_token
 
     # return acces token sandbox if environment is development
     if develop_env:
         logging.info("using developmental environment")
-        parameter_name = parameter_name + "_sandbox"
+        parameter_name = parameter_name + "_dev"
 
     logging.warn("no specified environment found")
     logging.info("retrieving access token from parameter %s" % parameter_name)

--- a/wherescape/connectors/hubspot/process_data.py
+++ b/wherescape/connectors/hubspot/process_data.py
@@ -106,7 +106,7 @@ def compare_names(source_names: list, destination_names: list):
 
     Parameters:
     - source_names (list) : list of column_names from the source table being used
-    - destination_names (list): lsit of all property names of the HubSpot object the data will go to
+    - destination_names (list): list of all property names of the HubSpot object the data will go to
 
     Returns:
     - known_destination_names (list) : list of property names that also exist as column names in the source table being used
@@ -116,15 +116,14 @@ def compare_names(source_names: list, destination_names: list):
     known_destination_names = []
 
     for name in source_names:
-        if name not in destination_names and name != "record_id":
+        if name not in destination_names and name != "record_id" and "dss_" not in name:
             """
             Only prints a warning if it doesn't have dss_ in it
             """
-            if "dss_" not in name:
-                logging.warning(
-                    "source name: %s does not exist in the destination. Please check its existence and spelling"
-                    % name
-                )
+            logging.warning(
+                "source name: %s does not exist in the destination. Please check its existence and spelling"
+                % name
+            )
         else:
             known_destination_names.append(name)
 

--- a/wherescape/connectors/hubspot/readme.md
+++ b/wherescape/connectors/hubspot/readme.md
@@ -21,8 +21,7 @@ Add the following parameter to WhereScape
 
 * `hubspot_access_token`
 
-Fill in the correct access token referring to the private app created in HubSpot
-For a connection with the Sandbox, add `_sandbox` to the above mentioned parameter.
+Fill in the correct access token referring to the private app created in HubSpot.
 
 ## load or stage table
 Create a load table for each HubSpot object where data will be sent to. 
@@ -51,6 +50,8 @@ specific can be replaced with the word specifying the environment.
 This word can by any word, as long as it is also mentioned in the table name. 
 for example, if the token name for an environment is `voys`, the table name could be `voys_stage_send_data` and the access token would be `hubspot_access_token_voys`.
 If only one environment exists, there's no need to specify the environment as the script will use the base name.
+
+For a connection with the Sandbox, add `_dev` at the end of the parameter 
 
 # Usage
 After creating the table, attach the host script to the table. 

--- a/wherescape/connectors/hubspot/readme.md
+++ b/wherescape/connectors/hubspot/readme.md
@@ -51,7 +51,7 @@ This word can by any word, as long as it is also mentioned in the table name.
 for example, if the token name for an environment is `voys`, the table name could be `voys_stage_send_data` and the access token would be `hubspot_access_token_voys`.
 If only one environment exists, there's no need to specify the environment as the script will use the base name.
 
-For a connection with the Sandbox, add `_dev` at the end of the parameter 
+For a connection with the Sandbox, add `_dev` at the end of the parameter.
 
 # Usage
 After creating the table, attach the host script to the table. 

--- a/wherescape/connectors/hubspot/readme.md
+++ b/wherescape/connectors/hubspot/readme.md
@@ -17,11 +17,12 @@ crm.objects.deals.read
 crm.objects.deals.write
 
 ## WhereScape Parameters
-Add the following paramter to WhereScape
+Add the following parameter to WhereScape
 
 * `hubspot_access_token`
 
 Fill in the correct access token referring to the private app created in HubSpot
+For a connection with the Sandbox, add `_sandbox` to the above mentioned parameter.
 
 ## load or stage table
 Create a load table for each HubSpot object where data will be sent to. 

--- a/wherescape/connectors/hubspot/readme.md
+++ b/wherescape/connectors/hubspot/readme.md
@@ -44,13 +44,16 @@ hubspot_load_data()
 ```
 
 ## multiple HubSpot environments
-If there are multiple environments, this script will distinguish which 
-To distinguish between multiple environments with different access tokens, a one word 
-name referring to the environment should be added at the end of the parameter `hubspot_access_token` and the table name.
-for example: if the environmentname would be "voys", the parameter would be called `hubspot_access_token_voys`
+If there are multiple environments, this script will be able to determine the desired environment
+using the names of the acccess token. This name consists of a required base name and an optional word specifying to the environment.
+The base name is `hubspot_access_token`. To specify which Hubspot environment, simply add `_{specific}` to the token name, where the word
+specific can be replaced with the word specifying the environment.
+This word can by any word, as long as it is also mentioned in the table name. 
+for example, if the token name for an environment is `voys`, the table name could be `voys_stage_send_data` and the access token would be `hubspot_access_token_voys`.
+If only one environment exists, there's no need to specify the environment as the script will use the base name.
 
 # Usage
 After creating the table, attach the host script to the table. 
 
 If multiple environments are used, make sure the name used to refer to the environment is 
-the same in both table name and the parameter `hubspot_access_token`
+the same in both table name and the parameter `hubspot_access_token`.


### PR DESCRIPTION
### Issue number

DATA-2017

### Description of fix
When running the script in one of the dev environments, it will use the sandbox access token.
This is based on whether dev shows.

### Other info

- I could only test it for dev1, so it would need to be checked in dev2 but I don't have access to those.
- I also added my local environment to gitignore. This is the standard file created by pyenv virtualenv
