### PR TITLE
DATA-1343 Fix UnboundLocalError in get_columns() when metadata return…

### DIFF
--- a/wherescape/wherescape.py
+++ b/wherescape/wherescape.py
@@ -107,6 +107,7 @@ class WhereScape:
             return None
 
         results = self.query_meta(sql, [self.object_key])
+        column_names, column_types = [], []
         if results:
             column_names = [result[0] for result in results]
             column_types = [result[1] for result in results]


### PR DESCRIPTION
## DATA-1343 — Fix `UnboundLocalError` in `get_columns()` when metadata returns no rows

### What

`get_columns()` raised `UnboundLocalError` when the WhereScape metadata query returned an empty result set, because `column_names` and `column_types` were only assigned inside the `if results:` branch but referenced unconditionally in the `return` statement.

### Why it matters

Any caller that invokes `get_columns()` on a load table with no columns registered in `ws_load_col` (e.g. a freshly created or misconfigured table) would get an unhandled `UnboundLocalError` instead of a clean empty result. This was surfaced while adding a new call to `get_columns()` in the Notion load script (DATA-1343).

### Change

`wherescape/wherescape.py` — initialize `column_names` and `column_types` to `[]` before the `if results:` guard so the function always returns a valid 2-tuple:

```python
# before
results = self.query_meta(sql, [self.object_key])
if results:
    column_names = [result[0] for result in results]
    column_types = [result[1] for result in results]
return (column_names, column_types)  # UnboundLocalError if results is empty

# after
results = self.query_meta(sql, [self.object_key])
column_names, column_types = [], []
if results:
    column_names = [result[0] for result in results]
    column_types = [result[1] for result in results]
return (column_names, column_types)  # always a valid 2-tuple
```

### Testing

- Existing callers unaffected — they already handle an empty list correctly.
- A call against a table with no columns in metadata now returns `([], [])` instead of raising.